### PR TITLE
Execution of apply-color made generic by offloading terminal selection to env variable TERMINAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ todo.MD
 .eslintcache
 public.tar.gz
 gin-bin
+.idea

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -44,10 +44,10 @@ func getListOfThemes() ([]byte, error) {
 
 // ApplyTheme function takes a theme name and installs it in current terminal
 func applyTheme(theme string) ([]byte, error) {
-	log.Println("Applying the theme: " + theme)
+	terminal := os.Getenv("TERMINAL")
+	log.Println("Applying the theme: " + theme + " in terminal " + terminal)
 	themeFilePath := path.Join(themesDir, theme)
-	cmd := exec.Command("x-terminal-emulator", "-e", "bash", themeFilePath)
-
+	cmd := exec.Command(themeFilePath)
 	return cmd.CombinedOutput()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,7 @@ func listThemesAPI(w http.ResponseWriter, r *http.Request) {
 
 func applyThemeAPI(w http.ResponseWriter, r *http.Request) {
 	enableCORS(&w)
+	var output []byte
 
 	if r.Method == "POST" {
 		var theme themeStruct
@@ -29,7 +30,11 @@ func applyThemeAPI(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		_, err = applyTheme(theme.Theme)
+		output, err = applyTheme(theme.Theme)
+		if err != nil {
+			// print error for debugging
+			log.Printf(string(output))
+		}
 		sendResponseOrError(w, err, []byte("Theme applied successfully"))
 	}
 }


### PR DESCRIPTION
1 - Execution of apply-color made generic by offloading terminal selection to env variable TERMINAL
2 - Printing in case of error post execution of apply-color added for debugging